### PR TITLE
docs: hive-owned STT/TTS + homelab-vs-service scaling note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Audio is streamed from this device to a [HiveMind](https://github.com/JarbasHive
 | Satellite | Mic | VAD | Wakeword | STT | TTS | Best for |
 |---|---|---|---|---|---|---|
 | [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | — | — | — | — | — | Text-only (keyboard/script) |
-| **hivemind-mic-satellite** (this repo) | local | local | **server** | **server** | **server** | Cheapest HW, zero local models |
-| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | local | local | local | **server** | **server** | Mid-range: local wakeword |
+| **hivemind-mic-satellite** (this repo) | local | local | **server** | **server** | **server** | Cheapest HW / homelab; no local models |
+| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | local | local | local | **server** | **server** | Local wakeword; scales as a service |
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | local | local | local | local | local | Full local stack, sends text |
 
 ---
@@ -25,6 +25,14 @@ Audio is streamed from this device to a [HiveMind](https://github.com/JarbasHive
 
 > **Important:** The default `hivemind-core` does not include audio processing.  
 > You need [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) installed server-side to enable server-side wakeword, STT, and TTS.
+
+---
+
+## Why mic-satellite — and when not to
+
+mic-satellite exists for one reason: **device resources**. With only a microphone and VAD on-device, it runs on the cheapest hardware (a Raspberry Pi Zero, a recycled phone) with zero local models. Everything else — wakeword, STT, intent, TTS — is **owned by the hive** and gated behind the same access-key authentication as the rest of the mesh. The hive operator decides the engines, models, and voice, uniformly; a satellite cannot override them. (Same ownership model as [voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) — see its docs for the "HiveMind as a service" framing.)
+
+**The trade-off, and the limit.** Because there is no local wakeword, the satellite streams **every** detected voice segment upstream (VAD-gated, but not gated by a wakeword). That continuous audio stream is bandwidth-heavy and puts the full STT load on the server for *all* speech, not just commands. It is the right call for a **homelab with a handful of personal devices**, where on-device resources are the binding constraint. It does **not** scale for **HiveMind-as-a-service** across many tenants — streaming raw audio per client is too costly. For a scalable, service-style deployment, prefer [voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay): local wakeword means audio only leaves the device after activation.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,10 @@ The entire on-device processing pipeline is:
 
 ---
 
+## Scaling: homelab vs service
+
+There is no local wakeword on mic-satellite, so the VAD ships **every** speech segment to the hive — not just post-activation commands. That keeps the device trivially cheap but makes the upstream a continuous raw-audio stream, with the server bearing the full STT cost for all speech. This is fine for a **homelab with a few personal devices**. It does **not** scale for a multi-tenant **HiveMind-as-a-service** offering: per-client raw-audio streaming is too bandwidth- and compute-heavy. A [voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) device, which only streams after a local wakeword fires, is the service-appropriate pattern. Both delegate STT/TTS to the hive (owned, authenticated); they differ in *how much* audio crosses the wire and therefore in how they scale.
+
 ## TTS playback path
 
 When the hive sends a `speak` message:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 **hivemind-mic-satellite** is the thinnest HiveMind satellite. Only a Microphone plugin and a VAD (Voice Activity Detection) plugin run on the device. When voice activity is detected, raw audio chunks are streamed over the HiveMind WebSocket connection to the server, which performs wakeword detection, speech-to-text, intent processing, and text-to-speech synthesis. The satellite receives the synthesised TTS audio and plays it back locally.
 
+Wakeword, STT, and TTS are **owned by the hive** and sit behind its access-key authentication — the hive operator chooses the engines and voice, not the device. mic-satellite is the **resource** choice (cheapest hardware, no local models). Note its limit: with no local wakeword it streams *all* detected voice activity, which is bandwidth-heavy and suits a **homelab with personal devices** rather than **HiveMind-as-a-service** at scale. For a service-style deployment, [voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) gates audio behind a local wakeword and scales better.
+
 No local speech models are required. The device is essentially a smart microphone with a speaker attached to the hive.
 
 ---
@@ -11,8 +13,8 @@ No local speech models are required. The device is essentially a smart microphon
 | Satellite | Mic | VAD | Wakeword | STT | TTS | Best for |
 |---|---|---|---|---|---|---|
 | [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | — | — | — | — | — | Text-only (keyboard/script) |
-| **hivemind-mic-satellite** (this repo) | local | local | **server** | **server** | **server** | Cheapest HW, zero local models |
-| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | local | local | local | **server** | **server** | Mid-range: local wakeword |
+| **hivemind-mic-satellite** (this repo) | local | local | **server** | **server** | **server** | Cheapest HW / homelab; no local models |
+| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | local | local | local | **server** | **server** | Local wakeword; scales as a service |
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | local | local | local | local | local | Full local stack, sends text |
 
 ---


### PR DESCRIPTION
Adds the shared 'hive owns STT/TTS, behind auth' framing, and notes mic-satellite's limit: with no local wakeword it streams all voice activity, which suits a **homelab with personal devices** but does **not** scale for HiveMind-as-a-service (use voice-relay's wakeword-gated pattern for that). (Stranded on the squash-merged #36 branch — re-landing off dev.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified mic-satellite positioning as the resource-efficient, homelab-friendly option with no local models
  * Added new section explaining scaling considerations between homelab deployments and centralized service models
  * Updated satellite spectrum descriptions to better contrast different deployment patterns and their bandwidth/scalability trade-offs
  * Emphasized key architectural differences in wakeword handling and authentication models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->