### PR TITLE
docs: correct claims that no longer match the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [docs/configuration.md](docs/configuration.md) for all options, plugin selec
 | Microphone | Yes | Captures audio from hardware |
 | VAD | Yes | Detects voice activity, decides when to stream |
 | PHAL | No | Platform/hardware abstraction (for example LEDs, buttons) |
+| Audio Transformers | No | Mutate microphone audio per chunk before it is streamed |
 | TTS Transformers | No | Mutate TTS audio before playback |
 | G2P | No | Visemes for mouth movement (for example Mycroft Mk1) |
 | Media Playback | No | Media commands such as "play Metallica" |
@@ -117,7 +118,7 @@ See [docs/configuration.md](docs/configuration.md) for all options, plugin selec
 - Wakeword detection
 - Continuous listening, hybrid listening, sleep mode, recording mode
 - Multiple wakewords
-- Audio and dialog transformer plugins
+- Dialog transformer plugins
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ When the hive sends a `speak` message:
 
 ## Session and identity
 
-- Each satellite has a `NodeIdentity`, stored in `~/.local/share/hivemind-client/identity.json`, with an `access_key`, `password`, `default_master` (host), and an optional `site_id`.
+- Each satellite has a `NodeIdentity`, stored in `~/.config/hivemind/_identity.json`, with an `access_key`, `password`, `default_master` (host), and an optional `site_id`.
 - The `site_id` / `--siteid` flag is injected into `message.context` so the hive knows which physical location the audio came from.
 - A `Session` is created locally (`FakeBus(session=Session())`) and shared between the internal bus and the playback thread for message routing.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@
 
 ## CLI flags
 
-All flags are optional. If a flag is omitted, the value is read from the identity file (`~/.local/share/hivemind-client/identity.json`).
+All flags are optional. If a flag is omitted, the value is read from the identity file (`~/.config/hivemind/_identity.json`).
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
@@ -29,7 +29,7 @@ hivemind-mic-sat \
 
 ## Identity file
 
-`hivemind-client set-identity` writes `~/.local/share/hivemind-client/identity.json`. All fields correspond to the CLI flags above. Once set, you can run `hivemind-mic-sat` with no arguments.
+`hivemind-client set-identity` writes `~/.config/hivemind/_identity.json`. All fields correspond to the CLI flags above. Once set, you can run `hivemind-mic-sat` with no arguments.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ hivemind-client set-identity \
   --host <hive-ip-or-hostname>
 ```
 
-The identity is written to `~/.local/share/hivemind-client/identity.json`. The `hivemind-mic-sat` command reads it automatically on startup.
+The identity is written to `~/.config/hivemind/_identity.json`. The `hivemind-mic-sat` command reads it automatically on startup.
 
 **Option B: pass credentials on the command line:**
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Part of an ecosystem-wide documentation accuracy pass. Five audit passes cross-checked every documented claim against freshly-synced `dev` source; this branch carries the corrections for this repo. Each fix cites the source that disproves the old wording.

Two findings turned out to be **code** bugs rather than doc bugs, and are reported separately rather than papered over here:
- the MicroPython client answers PING with a `pong` frame using wire code 13, which is unassigned in the reference `_INT2TYPE`, so a reference decoder rejects it;
- `emit_intercom` sends a hybrid envelope (`encrypted_key`/`ciphertext`/`tag`/`nonce`) while hivemind-core RSA-decrypts the `ciphertext` field directly, so an INTERCOM addressed to the hub itself cannot be decrypted. Peer-to-peer INTERCOM relayed through the hub is unaffected.